### PR TITLE
[settings.xml] Fix Snes9x settings

### DIFF
--- a/game.libretro.snes9x/resources/language/English/strings.po
+++ b/game.libretro.snes9x/resources/language/English/strings.po
@@ -79,3 +79,7 @@ msgstr ""
 msgctxt "#30015"
 msgid "Enable sound channel 8"
 msgstr ""
+
+msgctxt "#30016"
+msgid "SuperFX Overclock"
+msgstr ""

--- a/game.libretro.snes9x/resources/settings.xml
+++ b/game.libretro.snes9x/resources/settings.xml
@@ -1,21 +1,22 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
 	<category label="30000">
-		<setting label="30001" type="labelenum" id="s9x_layer_1" values="Yes|No" default="Yes"/>
-		<setting label="30002" type="labelenum" id="s9x_layer_2" values="Yes|No" default="Yes"/>
-		<setting label="30003" type="labelenum" id="s9x_layer_3" values="Yes|No" default="Yes"/>
-		<setting label="30004" type="labelenum" id="s9x_layer_4" values="Yes|No" default="Yes"/>
-		<setting label="30005" type="labelenum" id="s9x_layer_5" values="Yes|No" default="Yes"/>
-		<setting label="30006" type="labelenum" id="s9x_gfx_clip" values="Yes|No" default="Yes"/>
-		<setting label="30007" type="labelenum" id="s9x_gfx_transp" values="Yes|No" default="Yes"/>
-		<setting label="30008" type="labelenum" id="s9x_sndchan_1" values="Yes|No" default="Yes"/>
-		<setting label="30009" type="labelenum" id="s9x_sndchan_2" values="Yes|No" default="Yes"/>
-		<setting label="30010" type="labelenum" id="s9x_sndchan_3" values="Yes|No" default="Yes"/>
-		<setting label="30011" type="labelenum" id="s9x_sndchan_4" values="Yes|No" default="Yes"/>
-		<setting label="30012" type="labelenum" id="s9x_sndchan_5" values="Yes|No" default="Yes"/>
-		<setting label="30013" type="labelenum" id="s9x_sndchan_6" values="Yes|No" default="Yes"/>
-		<setting label="30014" type="labelenum" id="s9x_sndchan_7" values="Yes|No" default="Yes"/>
-		<setting label="30015" type="labelenum" id="s9x_sndchan_8" values="Yes|No" default="Yes"/>
+		<setting label="30016" type="labelenum" id="snes9x_overclock" values="disabled|40MHz|60MHz|80MHz|100MHz" default="disabled"/>
+		<setting label="30001" type="labelenum" id="snes9x_layer_1" values="Yes|No" default="Yes"/>
+		<setting label="30002" type="labelenum" id="snes9x_layer_2" values="Yes|No" default="Yes"/>
+		<setting label="30003" type="labelenum" id="snes9x_layer_3" values="Yes|No" default="Yes"/>
+		<setting label="30004" type="labelenum" id="snes9x_layer_4" values="Yes|No" default="Yes"/>
+		<setting label="30005" type="labelenum" id="snes9x_layer_5" values="Yes|No" default="Yes"/>
+		<setting label="30006" type="labelenum" id="snes9x_gfx_clip" values="Yes|No" default="Yes"/>
+		<setting label="30007" type="labelenum" id="snes9x_gfx_transp" values="Yes|No" default="Yes"/>
+		<setting label="30008" type="labelenum" id="snes9x_sndchan_1" values="Yes|No" default="Yes"/>
+		<setting label="30009" type="labelenum" id="snes9x_sndchan_2" values="Yes|No" default="Yes"/>
+		<setting label="30010" type="labelenum" id="snes9x_sndchan_3" values="Yes|No" default="Yes"/>
+		<setting label="30011" type="labelenum" id="snes9x_sndchan_4" values="Yes|No" default="Yes"/>
+		<setting label="30012" type="labelenum" id="snes9x_sndchan_5" values="Yes|No" default="Yes"/>
+		<setting label="30013" type="labelenum" id="snes9x_sndchan_6" values="Yes|No" default="Yes"/>
+		<setting label="30014" type="labelenum" id="snes9x_sndchan_7" values="Yes|No" default="Yes"/>
+		<setting label="30015" type="labelenum" id="snes9x_sndchan_8" values="Yes|No" default="Yes"/>
 	</category>
 </settings>
 


### PR DESCRIPTION
Snes9x settings have been renamed from s9x_\* to snes9x_*.
Setting snes9x_next_overclock was added.
