### PR TITLE
remove trailing period

### DIFF
--- a/game.libretro.snes9x/addon.xml
+++ b/game.libretro.snes9x/addon.xml
@@ -5,7 +5,7 @@
 		provider-name="Libretro">
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>
-		<import addon="game.controller.snes" version="1.0.0."/>
+		<import addon="game.controller.snes" version="1.0.0"/>
 	</requires>
 	<extension point="kodi.gameclient"
                    library_android="libgame.libretro.snes9x.so"


### PR DESCRIPTION
This causes the add-on to be marked as incompatible because there is no such version as 1.0.0. of game.controller.snes
