### PR TITLE
Import buttonmaps for additional controllers

### DIFF
--- a/game.libretro.snes9x/addon.xml.in
+++ b/game.libretro.snes9x/addon.xml.in
@@ -6,6 +6,10 @@
 	<requires>
 		<import addon="game.libretro" version="1.0.0"/>
 		<import addon="game.controller.snes" version="1.0.0"/>
+		<import addon="game.controller.snes.mouse" version="1.0.0"/>
+		<import addon="game.controller.snes.multitap" version="1.0.0"/>
+		<import addon="game.controller.snes.super.scope" version="1.0.0"/>
+		<import addon="game.controller.konami.justifier" version="1.0.0"/>
 	</requires>
 	<extension point="kodi.gameclient"
 			library_@PLATFORM@="@LIBRARY_FILENAME@">

--- a/game.libretro.snes9x/resources/buttonmap.xml
+++ b/game.libretro.snes9x/resources/buttonmap.xml
@@ -14,4 +14,29 @@
     <feature name="rightbumper" mapto="RETRO_DEVICE_ID_JOYPAD_R"/>
     <feature name="leftbumper" mapto="RETRO_DEVICE_ID_JOYPAD_L"/>
   </controller>
+  <controller id="game.controller.snes.mouse" type="RETRO_DEVICE_MOUSE">
+    <feature name="left" mapto="RETRO_DEVICE_ID_MOUSE_LEFT"/>
+    <feature name="right" mapto="RETRO_DEVICE_ID_MOUSE_RIGHT"/>
+    <feature name="pointer" mapto="RETRO_DEVICE_MOUSE"/>
+  </controller>
+  <controller id="game.controller.snes.multitap" type="RETRO_DEVICE_JOYPAD" class="0"/>
+  <controller id="game.controller.snes.super.scope" type="RETRO_DEVICE_LIGHTGUN" class="0">
+    <feature name="trigger" mapto="RETRO_DEVICE_ID_LIGHTGUN_TRIGGER"/>
+    <feature name="cursor" mapto="RETRO_DEVICE_ID_LIGHTGUN_CURSOR"/>
+    <feature name="turbo" mapto="RETRO_DEVICE_ID_LIGHTGUN_TURBO"/>
+    <feature name="pause" mapto="RETRO_DEVICE_ID_LIGHTGUN_PAUSE"/>
+    <feature name="crosshair" mapto="RETRO_DEVICE_LIGHTGUN"/>
+  </controller>
+  <controller id="game.controller.konami.justifier" model="blue" type="RETRO_DEVICE_LIGHTGUN" class="1">
+    <feature name="trigger" mapto="RETRO_DEVICE_ID_LIGHTGUN_TRIGGER"/>
+    <feature name="start" mapto="RETRO_DEVICE_ID_LIGHTGUN_PAUSE"/>
+    <feature name="offscreen" mapto="RETRO_DEVICE_ID_LIGHTGUN_TURBO"/>
+    <feature name="crosshair" mapto="RETRO_DEVICE_LIGHTGUN"/>
+  </controller>
+  <controller id="game.controller.konami.justifier" model="pink" type="RETRO_DEVICE_LIGHTGUN" class="2">
+    <feature name="trigger" mapto="RETRO_DEVICE_ID_LIGHTGUN_TRIGGER"/>
+    <feature name="start" mapto="RETRO_DEVICE_ID_LIGHTGUN_PAUSE"/>
+    <feature name="offscreen" mapto="RETRO_DEVICE_ID_LIGHTGUN_TURBO"/>
+    <feature name="crosshair" mapto="RETRO_DEVICE_LIGHTGUN"/>
+  </controller>
 </buttonmap>


### PR DESCRIPTION
This imports buttonmaps for the following controllers:

* SNES Mouse
* Super Multitap
* Super Scope
* Justifier lightgun

Data was scraped from Snes9x source: https://github.com/libretro/snes9x/blob/master/libretro/libretro.cpp