### PR TITLE
Add logical controller topology

### DIFF
--- a/game.libretro.snes9x/addon.xml.in
+++ b/game.libretro.snes9x/addon.xml.in
@@ -9,8 +9,7 @@
 		<import addon="game.controller.snes.mouse" version="1.0.0"/>
 		<import addon="game.controller.snes.multitap" version="1.0.0"/>
 		<import addon="game.controller.snes.super.scope" version="1.0.0"/>
-		<import addon="game.controller.konami.justifier.blue" version="1.0.0"/>
-		<import addon="game.controller.konami.justifier.pink" version="1.0.0"/>
+		<import addon="game.controller.konami.justifier.snes" version="1.0.0"/>
 	</requires>
 	<extension point="kodi.gameclient"
 			library_@PLATFORM@="@LIBRARY_FILENAME@">

--- a/game.libretro.snes9x/addon.xml.in
+++ b/game.libretro.snes9x/addon.xml.in
@@ -9,7 +9,8 @@
 		<import addon="game.controller.snes.mouse" version="1.0.0"/>
 		<import addon="game.controller.snes.multitap" version="1.0.0"/>
 		<import addon="game.controller.snes.super.scope" version="1.0.0"/>
-		<import addon="game.controller.konami.justifier" version="1.0.0"/>
+		<import addon="game.controller.konami.justifier.blue" version="1.0.0"/>
+		<import addon="game.controller.konami.justifier.pink" version="1.0.0"/>
 	</requires>
 	<extension point="kodi.gameclient"
 			library_@PLATFORM@="@LIBRARY_FILENAME@">

--- a/game.libretro.snes9x/resources/buttonmap.xml
+++ b/game.libretro.snes9x/resources/buttonmap.xml
@@ -27,13 +27,7 @@
     <feature name="pause" mapto="RETRO_DEVICE_ID_LIGHTGUN_PAUSE"/>
     <feature name="crosshair" mapto="RETRO_DEVICE_LIGHTGUN"/>
   </controller>
-  <controller id="game.controller.konami.justifier.blue" type="RETRO_DEVICE_LIGHTGUN" class="1">
-    <feature name="trigger" mapto="RETRO_DEVICE_ID_LIGHTGUN_TRIGGER"/>
-    <feature name="start" mapto="RETRO_DEVICE_ID_LIGHTGUN_PAUSE"/>
-    <feature name="offscreen" mapto="RETRO_DEVICE_ID_LIGHTGUN_TURBO"/>
-    <feature name="crosshair" mapto="RETRO_DEVICE_LIGHTGUN"/>
-  </controller>
-  <controller id="game.controller.konami.justifier.pink" type="RETRO_DEVICE_LIGHTGUN" class="2">
+  <controller id="game.controller.konami.justifier.snes" type="RETRO_DEVICE_LIGHTGUN" class="1">
     <feature name="trigger" mapto="RETRO_DEVICE_ID_LIGHTGUN_TRIGGER"/>
     <feature name="start" mapto="RETRO_DEVICE_ID_LIGHTGUN_PAUSE"/>
     <feature name="offscreen" mapto="RETRO_DEVICE_ID_LIGHTGUN_TURBO"/>

--- a/game.libretro.snes9x/resources/buttonmap.xml
+++ b/game.libretro.snes9x/resources/buttonmap.xml
@@ -27,13 +27,13 @@
     <feature name="pause" mapto="RETRO_DEVICE_ID_LIGHTGUN_PAUSE"/>
     <feature name="crosshair" mapto="RETRO_DEVICE_LIGHTGUN"/>
   </controller>
-  <controller id="game.controller.konami.justifier" model="blue" type="RETRO_DEVICE_LIGHTGUN" class="1">
+  <controller id="game.controller.konami.justifier.blue" type="RETRO_DEVICE_LIGHTGUN" class="1">
     <feature name="trigger" mapto="RETRO_DEVICE_ID_LIGHTGUN_TRIGGER"/>
     <feature name="start" mapto="RETRO_DEVICE_ID_LIGHTGUN_PAUSE"/>
     <feature name="offscreen" mapto="RETRO_DEVICE_ID_LIGHTGUN_TURBO"/>
     <feature name="crosshair" mapto="RETRO_DEVICE_LIGHTGUN"/>
   </controller>
-  <controller id="game.controller.konami.justifier" model="pink" type="RETRO_DEVICE_LIGHTGUN" class="2">
+  <controller id="game.controller.konami.justifier.pink" type="RETRO_DEVICE_LIGHTGUN" class="2">
     <feature name="trigger" mapto="RETRO_DEVICE_ID_LIGHTGUN_TRIGGER"/>
     <feature name="start" mapto="RETRO_DEVICE_ID_LIGHTGUN_PAUSE"/>
     <feature name="offscreen" mapto="RETRO_DEVICE_ID_LIGHTGUN_TURBO"/>

--- a/game.libretro.snes9x/resources/topology.xml
+++ b/game.libretro.snes9x/resources/topology.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<logicaltopology>
+  <port id="1">
+    <accepts controller="game.controller.snes"/>
+    <accepts controller="game.controller.snes.mouse"/>
+    <accepts controller="game.controller.snes.multitap">
+      <port id="1">
+        <accepts controller="game.controller.snes"/>
+      </port>
+      <port id="2">
+        <accepts controller="game.controller.snes"/>
+      </port>
+      <port id="3">
+        <accepts controller="game.controller.snes"/>
+      </port>
+      <port id="4">
+        <accepts controller="game.controller.snes"/>
+      </port>
+    </accepts>
+  </port>
+  <port id="2">
+    <accepts controller="game.controller.snes"/>
+    <accepts controller="game.controller.snes.mouse"/>
+    <accepts controller="game.controller.snes.multitap">
+      <port id="1">
+        <accepts controller="game.controller.snes"/>
+      </port>
+      <port id="2">
+        <accepts controller="game.controller.snes"/>
+      </port>
+      <port id="3">
+        <accepts controller="game.controller.snes"/>
+      </port>
+      <port id="4">
+        <accepts controller="game.controller.snes"/>
+      </port>
+    </accepts>
+    <accepts controller="game.controller.snes.super.scope"/>
+    <accepts controller="game.controller.konami.justifier" model="blue"/>
+  </port>
+</logicaltopology>

--- a/game.libretro.snes9x/resources/topology.xml
+++ b/game.libretro.snes9x/resources/topology.xml
@@ -36,6 +36,6 @@
       </port>
     </accepts>
     <accepts controller="game.controller.snes.super.scope"/>
-    <accepts controller="game.controller.konami.justifier" model="blue"/>
+    <accepts controller="game.controller.konami.justifier.blue"/>
   </port>
 </logicaltopology>

--- a/game.libretro.snes9x/resources/topology.xml
+++ b/game.libretro.snes9x/resources/topology.xml
@@ -36,6 +36,6 @@
       </port>
     </accepts>
     <accepts controller="game.controller.snes.super.scope"/>
-    <accepts controller="game.controller.konami.justifier.blue"/>
+    <accepts controller="game.controller.konami.justifier.snes"/>
   </port>
 </logicaltopology>


### PR DESCRIPTION
Logical topology specifies which controller connections are supported by the emulator.

By contrast, physical topology specifies which connections are physically compatible. For example, see [game.controller.snes.multitap/resources/layout.xml](https://github.com/kodi-game/kodi-game-controllers/blob/master/addons/game.controller.snes.multitap/resources/layout.xml).

Data was scraped from Snes9x source: https://github.com/libretro/snes9x/blob/master/libretro/libretro.cpp