### PR TITLE
Extend topology.xml for Multitap support

### DIFF
--- a/game.libretro.snes9x/resources/topology.xml
+++ b/game.libretro.snes9x/resources/topology.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <logicaltopology>
-  <port type="controller" id="1">
+  <port type="controller" id="1" connectionPort="0">
     <accepts controller="game.controller.snes"/>
     <accepts controller="game.controller.snes.mouse"/>
     <accepts controller="game.controller.snes.multitap">
-      <port type="controller" id="1">
+      <port type="controller" id="1" connectionPort="-1">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port type="controller" id="2">
+      <port type="controller" id="2" connectionPort="-1">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port type="controller" id="3">
+      <port type="controller" id="3" connectionPort="-1">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port type="controller" id="4">
+      <port type="controller" id="4" connectionPort="-1">
         <accepts controller="game.controller.snes"/>
       </port>
     </accepts>
   </port>
-  <port type="controller" id="2">
+  <port type="controller" id="2" connectionPort="1">
     <accepts controller="game.controller.snes"/>
     <accepts controller="game.controller.snes.mouse"/>
     <accepts controller="game.controller.snes.multitap">
-      <port type="controller" id="1">
+      <port type="controller" id="1" connectionPort="-1">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port type="controller" id="2">
+      <port type="controller" id="2" connectionPort="-1">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port type="controller" id="3">
+      <port type="controller" id="3" connectionPort="-1">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port type="controller" id="4">
+      <port type="controller" id="4" connectionPort="-1">
         <accepts controller="game.controller.snes"/>
       </port>
     </accepts>

--- a/game.libretro.snes9x/resources/topology.xml
+++ b/game.libretro.snes9x/resources/topology.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <logicaltopology>
-  <port id="1">
+  <port type="controller" id="1">
     <accepts controller="game.controller.snes"/>
     <accepts controller="game.controller.snes.mouse"/>
     <accepts controller="game.controller.snes.multitap">
-      <port id="1">
+      <port type="controller" id="1">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port id="2">
+      <port type="controller" id="2">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port id="3">
+      <port type="controller" id="3">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port id="4">
+      <port type="controller" id="4">
         <accepts controller="game.controller.snes"/>
       </port>
     </accepts>
   </port>
-  <port id="2">
+  <port type="controller" id="2">
     <accepts controller="game.controller.snes"/>
     <accepts controller="game.controller.snes.mouse"/>
     <accepts controller="game.controller.snes.multitap">
-      <port id="1">
+      <port type="controller" id="1">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port id="2">
+      <port type="controller" id="2">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port id="3">
+      <port type="controller" id="3">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port id="4">
+      <port type="controller" id="4">
         <accepts controller="game.controller.snes"/>
       </port>
     </accepts>

--- a/game.libretro.snes9x/resources/topology.xml
+++ b/game.libretro.snes9x/resources/topology.xml
@@ -4,16 +4,16 @@
     <accepts controller="game.controller.snes"/>
     <accepts controller="game.controller.snes.mouse"/>
     <accepts controller="game.controller.snes.multitap">
-      <port type="controller" id="1" connectionPort="-1">
+      <port type="controller" id="1" connectionPort="-1" forceConnected="true">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port type="controller" id="2" connectionPort="-1">
+      <port type="controller" id="2" connectionPort="-1" forceConnected="true">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port type="controller" id="3" connectionPort="-1">
+      <port type="controller" id="3" connectionPort="-1" forceConnected="true">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port type="controller" id="4" connectionPort="-1">
+      <port type="controller" id="4" connectionPort="-1" forceConnected="true">
         <accepts controller="game.controller.snes"/>
       </port>
     </accepts>
@@ -22,16 +22,16 @@
     <accepts controller="game.controller.snes"/>
     <accepts controller="game.controller.snes.mouse"/>
     <accepts controller="game.controller.snes.multitap">
-      <port type="controller" id="1" connectionPort="-1">
+      <port type="controller" id="1" connectionPort="-1" forceConnected="true">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port type="controller" id="2" connectionPort="-1">
+      <port type="controller" id="2" connectionPort="-1" forceConnected="true">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port type="controller" id="3" connectionPort="-1">
+      <port type="controller" id="3" connectionPort="-1" forceConnected="true">
         <accepts controller="game.controller.snes"/>
       </port>
-      <port type="controller" id="4" connectionPort="-1">
+      <port type="controller" id="4" connectionPort="-1" forceConnected="true">
         <accepts controller="game.controller.snes"/>
       </port>
     </accepts>


### PR DESCRIPTION
## Description

This PR extends topology.xml with some new features needed for Multitap support.

The Snes9x cores allow for Multitaps to be enabled by connecting the appropriate controller ports. However, the ports used for controller connection have different indices from the ports used for polling input. Polling input follows depth-first assignment of input devices (so skipping multitaps). However, connecting controllers uses specifically port 0 and 1. You can only configure which device is connected to the hardware ports, not to child ports on the Multitap.

This required two features:

* Libretro port - Not sure what to call this, but it's the libretro port to use when connecting/disconnecting controllers
* Allow disconnect - Needed because Snes9x's depth-first logic doesn't allow for multitap controllers to be disconnected

I'm preparing a PR for these two features, and I intend to open it after some testing with my test builds.

## How has this been tested?

Tested with my new Port Setup dialog.